### PR TITLE
Minor changes

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -5,8 +5,6 @@
 ###############################################
 . ./include.sh
 
-VERSION=2.0.0-SNAPSHOT
-RADARGUN_HOME=$SHARED_DIR/RadarGun-$VERSION
 BENCHMARK_CONFIG=$1
 SLAVES=${2:-$DEFAULT_SLAVES}
 MASTER=$INSTANCE_PREFIX-master

--- a/include.sh
+++ b/include.sh
@@ -11,21 +11,26 @@ SHARED_DIR=/mnt/shared
 SHARED_DISK_NAME=shared
 SHARED_DISK_DEV=/dev/disk/by-id/google-$SHARED_DISK_NAME
 REMOTE_HOME=$HOME
-LOCAL_CONFIG_DIR=$HOME/workspace/etc
+#LOCAL_CONFIG_DIR=$HOME/workspace/etc
+LOCAL_CONFIG_DIR=$HOME/Development/projects/etc
 REMOTE_CONFIG_DIR=$REMOTE_HOME/etc
 DEFAULT_SLAVES=32
 DEFAULT_RESULTS_DIR=/tmp/results
-BROWSER=firefox
+#BROWSER=firefox
+BROWSER=chrome
 MAX_CONCURRENCY=32
+
+VERSION=2.1.0-SNAPSHOT
+RADARGUN_HOME=$SHARED_DIR/RadarGun-$VERSION
 
 ### Configuration for RadarGun jobs
 JGROUPS_PORT=7800
-JGROUPS_JAR=$SHARED_DIR/RadarGun-2.0.0-SNAPSHOT/plugins/infinispan70/lib/jgroups-3.6.1.Final.jar
+JGROUPS_JAR=$SHARED_DIR/RadarGun-2.1.0-SNAPSHOT/plugins/infinispan70/lib/jgroups-3.6.1.Final.jar
 CLUSTER_NAME=default
 
 ADD_CONFIGS=""
 #ADD_CONFIGS="$ADD_CONFIGS --add-config jdg64:$REMOTE_CONFIG_DIR/ispn-configs/infinispan60/dist-no-tx.xml"
-#ADD_CONFIGS="$ADD_CONFIGS --add-config jdg64:$REMOTE_CONFIG_DIR/jgroups/infinispan70/jgroups-google.xml"
+ADD_CONFIGS="$ADD_CONFIGS --add-config jdg65:$REMOTE_CONFIG_DIR/jgroups/infinispan70/jgroups-google.xml"
 #ADD_CONFIGS="$ADD_CONFIGS --add-config jdg64:$SHARED_DIR/RadarGun-2.0.0-SNAPSHOT/plugins/jdg63/conf/server.xml"
 ADD_CONFIGS="$ADD_CONFIGS --add-config jdg64:$REMOTE_HOME/etc/configs/default/gce.xml"
 

--- a/shared-ro.sh
+++ b/shared-ro.sh
@@ -8,7 +8,7 @@
 LAST_ID=`expr ${1:-$DEFAULT_SLAVES} - 1`
 
 echo "Detaching from $INSTANCE_PREFIX-master..."
-ssh -tt $INSTANCE_PREFIX-master 'sudo umount '$SHARED_DIR
+ssh -tt $INSTANCE_PREFIX-master 'sudo umount '$SHARED_DISK_DEV
 gcloud compute instances detach-disk $INSTANCE_PREFIX-master --disk $SHARED_DISK_NAME
 
 echo "Attaching to instances..."

--- a/shared-rw.sh
+++ b/shared-rw.sh
@@ -8,9 +8,9 @@
 LAST_ID=`expr ${1:-$DEFAULT_SLAVES} - 1`
 
 echo "Unmounting drives..."
-ssh -tt $INSTANCE_PREFIX-master sudo umount $SHARED_DIR &
+ssh -tt $INSTANCE_PREFIX-master sudo umount $SHARED_DISK_DEV &
 for ID in `seq 0 $LAST_ID`; do
-   ssh -tt $INSTANCE_PREFIX-$ID sudo umount $SHARED_DIR &
+   ssh -tt $INSTANCE_PREFIX-$ID sudo umount $SHARED_DISK_DEV &
    if [ `expr \( $ID + 1 \) % $MAX_CONCURRENCY` -eq 0 ]; then
       wait
    fi


### PR DESCRIPTION
Move RadarGun version and home variables from dist.sh to include.sh
Unmount Google disk device in shared-ro.sh and shared-rw.sh (Suggested in the "Detach a persistent disk" section of https://cloud.google.com/compute/docs/disks/persistent-disks)
